### PR TITLE
Add carabiner-dev/revex SLSA Source policy file

### DIFF
--- a/policy/github.com/carabiner-dev/revex/source-policy.json
+++ b/policy/github.com/carabiner-dev/revex/source-policy.json
@@ -1,0 +1,10 @@
+{
+  "canonical_repo": "https://github.com/carabiner-dev/revex.git",
+  "protected_branches": [
+    {
+      "since": "2025-08-02T03:28:37.441Z",
+      "name": "refs/heads/main",
+      "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the SLSA source policy for github.com/carabiner-dev/revex