### PR TITLE
Correct branch names in policies

### DIFF
--- a/policy/github.com/carabiner-dev/revex/source-policy.json
+++ b/policy/github.com/carabiner-dev/revex/source-policy.json
@@ -2,8 +2,8 @@
   "canonical_repo": "https://github.com/carabiner-dev/revex.git",
   "protected_branches": [
     {
-      "since": "2025-08-02T03:28:37.441Z",
-      "name": "refs/heads/main",
+      "since": "2025-08-02T03:39:04.679423705Z",
+      "name": "main",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
     }
   ]

--- a/policy/github.com/puerco/slsa-source-test/source-policy.json
+++ b/policy/github.com/puerco/slsa-source-test/source-policy.json
@@ -3,7 +3,7 @@
   "protected_branches": [
     {
       "since": "2025-07-28T08:18:16.582Z",
-      "name": "refs/heads/main",
+      "name": "main",
       "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
     }
   ]


### PR DESCRIPTION
This corrects the name on policies which were generated with the full ref on the branch name