### PR TITLE
Add carabiner-dev/demo-slsa-e2e SLSA Source policy file

### DIFF
--- a/policy/github.com/carabiner-dev/demo-slsa-e2e/source-policy.json
+++ b/policy/github.com/carabiner-dev/demo-slsa-e2e/source-policy.json
@@ -1,0 +1,14 @@
+{
+  "canonical_repo": "https://github.com/carabiner-dev/demo-slsa-e2e.git",
+  "protected_branches": [
+    {
+      "since": "2025-09-27T01:37:13.189Z",
+      "name": "main",
+      "target_slsa_source_level": "SLSA_SOURCE_LEVEL_3"
+    }
+  ],
+  "protected_tag": {
+    "since": "2025-09-27T01:37:13.189Z",
+    "tag_hygiene": true
+  }
+}


### PR DESCRIPTION
This pull request adds the SLSA source policy for github.com/carabiner-dev/demo-slsa-e2e